### PR TITLE
refactor(ci): use Go v1.22 as the minimum version in workflows

### DIFF
--- a/.anvil.lock
+++ b/.anvil.lock
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2024-02-11T11:55:29.586918499Z",
-  "version": "1.2.7",
+  "generated_at": "2024-02-22T13:17:37.733112748Z",
+  "version": "1.2.8",
   "files": [
     {
       "path": ".editorconfig"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -49,7 +49,7 @@ jobs:
         id: golang
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.21
+          go-version: ^1.22
 
       - name: Run generate
         id: generate

--- a/.github/workflows/go-binaries.yml
+++ b/.github/workflows/go-binaries.yml
@@ -28,7 +28,7 @@ jobs:
         id: golang
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.21
+          go-version: ^1.22
 
       - name: Run generate
         id: generate

--- a/.github/workflows/go-lint-test.yml
+++ b/.github/workflows/go-lint-test.yml
@@ -26,7 +26,7 @@ jobs:
         id: golang
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.21
+          go-version: ^1.22
 
       - name: install golangci
         uses: giantswarm/install-binary-action@v2.0.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ run:
   # golang-ci lint runtime timeout
   deadline: 5m
   # latest supported Go version
-  go: '1.21'
+  go: '1.22'
   # see: https://golangci-lint.run/usage/configuration/
   modules-download-mode: readonly
   # include test files or not.


### PR DESCRIPTION
Use Go v1.22 as the minimum version in workflows