### PR TITLE
fix: prerelease tag prefix matching, error returns, and stderr usage

### DIFF
--- a/cmd/semver-bump-action/main.go
+++ b/cmd/semver-bump-action/main.go
@@ -135,17 +135,16 @@ func incrementPrereleaseVersion(v *semver.Version, preReleaseTag string) (semver
 	}
 
 	// If there's an existing prerelease version, increment it
-	if strings.HasPrefix(prerelease, preReleaseTag) {
+	if strings.HasPrefix(prerelease, preReleaseTag+".") {
 		parts := strings.SplitN(prerelease, ".", 2)
 		if len(parts) == 2 {
 			number, err := strconv.Atoi(parts[1])
 			if err != nil {
 				// Handle conversion error, which includes negative numbers
-				return *v, fmt.Errorf("invalid prerelease format: %w", err)
+				return semver.Version{}, fmt.Errorf("invalid prerelease format: %w", err)
 			}
 			if number < 0 {
-				// Explicitly handle negative numbers
-				return *v, fmt.Errorf("negative number in prerelease is not valid")
+				return semver.Version{}, fmt.Errorf("negative number in prerelease is not valid")
 			}
 			number++
 			return v.SetPrerelease(fmt.Sprintf("%s.%d", preReleaseTag, number))

--- a/cmd/semver-bump-action/main_test.go
+++ b/cmd/semver-bump-action/main_test.go
@@ -43,6 +43,9 @@ func TestBumpSemver(t *testing.T) {
 		{"Empty Current Version", "", "major", "", "", true},
 		{"Non-numeric Version", "1.x.3", "major", "", "", true},
 		{"Unsupported Prerelease", "1.0.0", "premajor", "xyz123", "2.0.0-xyz123.0", false},
+
+		// Tag prefix collision: "alpha" must not match "alphabeta"
+		{"Prerelease Tag Prefix Collision", "1.2.3-alphabeta.5", "prerelease", "alpha", "1.2.3-alpha.0", false},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/semver-bump-action/output.go
+++ b/cmd/semver-bump-action/output.go
@@ -10,7 +10,7 @@ func writeOutput(key, value string) {
 	if ghOutput, exists := os.LookupEnv("GITHUB_OUTPUT"); exists {
 		f, err := os.OpenFile(ghOutput, os.O_APPEND|os.O_WRONLY, 0o644)
 		if err != nil {
-			fmt.Println("Error opening GITHUB_OUTPUT file:", err)
+			fmt.Fprintln(os.Stderr, "Error opening GITHUB_OUTPUT file:", err)
 			return
 		}
 
@@ -19,7 +19,7 @@ func writeOutput(key, value string) {
 
 		_, err = fmt.Fprintf(f, "%s=%s\n", key, value)
 		if err != nil {
-			fmt.Println("Error writing to GITHUB_OUTPUT file:", err)
+			fmt.Fprintln(os.Stderr, "Error writing to GITHUB_OUTPUT file:", err)
 		}
 	} else {
 		fmt.Printf("::set-output name=%s::%s\n", key, value)


### PR DESCRIPTION
## Summary

- **Prefix collision**: `incrementPrereleaseVersion` used `HasPrefix(prerelease, tag)` — tag `"alpha"` incorrectly matched `"alphabeta.5"`, corrupting the bump result. Fixed by matching `tag + "."`.
- **Error return values**: Error paths in `incrementPrereleaseVersion` returned `*v` (the original version) instead of a zero-value `semver.Version{}`, inconsistent with all other functions.
- **Errors on stdout**: `writeOutput` printed `GITHUB_OUTPUT` file errors to stdout via `fmt.Println`, which could corrupt action output. Changed to `fmt.Fprintln(os.Stderr, ...)`.

## Test plan

- [x] Added regression test for tag prefix collision (`"alphabeta"` vs `"alpha"`)
- [x] All existing tests pass